### PR TITLE
Add ENABLE_NPM_FAILOVER config with offline only mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ I believe all the above said tools will be available in a typical UNIX machine.
 # Configurations
 
 Please check config.js. All config values can be over-written by `environment-variables` 
+
+# Using npm-offline-registry as a completely isolated registry
+
+If you set the ``ENABLE_NPM_FAILOVER`` config value to ``false`` then npm-offlin-registry will not attempt to
+contact the upstream NPM registry for unknown packages and instead return a 404 response, meaning you can use
+it as an alternative to the NPM registry behind a firewall / isolated from the internet.

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var utils = require( __dirname + '/./utils');
 
 var NPM_PATH = config.NPM_PATH;
 var REGISTRY_NAME = config.REGISTRY_NAME;
+var ENABLE_NPM_FAILOVER = config.ENABLE_NPM_FAILOVER;
 
 
 var fetchAndCacheMetadata = utils.fetchAndCacheMetadata;
@@ -36,8 +37,12 @@ app.get( '/:package', function( req, res, next ){
   return fileExists( cacheFile )
     .tap( function( isExists ){
       if( !isExists ){
-        res._log.cacheHit = '---';
-        return fetchAndCacheMetadata( packageName, cacheFile );
+	if ( ENABLE_NPM_FAILOVER ) {
+	  res._log.cacheHit = '---';
+	  return fetchAndCacheMetadata( packageName, cacheFile );
+	} else {
+	  return res.status( 404 ).json( {} );
+	}
       }
     })
     .then( function( ){
@@ -60,8 +65,12 @@ app.get( '/:package/-/:tarball', function( req, res, next ){
   fileExists( packagePath )
     .tap( function( isExists ){
       if( !isExists ){
-        res._log.cacheHit = '---';
-        return fetchAndCacheTarball( packageName, version, packagePath );
+	if ( ENABLE_NPM_FAILOVER ) {
+	  res._log.cacheHit = '---';
+	  return fetchAndCacheTarball( packageName, version, packagePath );
+	} else {
+	  return res.status( 404 ).json( {} );
+	}
       }
     })
     .then( function(){

--- a/app.js
+++ b/app.js
@@ -37,12 +37,12 @@ app.get( '/:package', function( req, res, next ){
   return fileExists( cacheFile )
     .tap( function( isExists ){
       if( !isExists ){
-	if ( ENABLE_NPM_FAILOVER ) {
-	  res._log.cacheHit = '---';
-	  return fetchAndCacheMetadata( packageName, cacheFile );
-	} else {
-	  return res.status( 404 ).json( {} );
-	}
+        if ( ENABLE_NPM_FAILOVER ) {
+          res._log.cacheHit = '---';
+          return fetchAndCacheMetadata( packageName, cacheFile );
+        } else {
+          return res.status( 404 ).json( {} );
+        }
       }
     })
     .then( function( ){
@@ -65,12 +65,12 @@ app.get( '/:package/-/:tarball', function( req, res, next ){
   fileExists( packagePath )
     .tap( function( isExists ){
       if( !isExists ){
-	if ( ENABLE_NPM_FAILOVER ) {
-	  res._log.cacheHit = '---';
-	  return fetchAndCacheTarball( packageName, version, packagePath );
-	} else {
-	  return res.status( 404 ).json( {} );
-	}
+        if ( ENABLE_NPM_FAILOVER ) {
+          res._log.cacheHit = '---';
+          return fetchAndCacheTarball( packageName, version, packagePath );
+        } else {
+          return res.status( 404 ).json( {} );
+        }
       }
     })
     .then( function(){

--- a/config.js
+++ b/config.js
@@ -2,7 +2,8 @@
 var defaultConfig = {
   NPM_PATH       : process.env.HOME + '/.npm',
   REGISTRY_NAME  : 'registry.npmjs.org',
-  PORT: 8234
+  PORT: 8234,
+  ENABLE_NPM_FAILOVER: true
 };
 
 var config = {};


### PR DESCRIPTION
Hi there,

Firstly I love the simplicity of this module compared to similar local NPM registry implementations.

One thing we need for our own purposes is the ability to run completely in isolation inside our build servers VPN, so I've added an `ENABLE_NPM_FAILOVER` option that defaults to `true` which makes npm-offline-registry work just as it did before, deferring upstream for unknown packages, but if you set it to `false` it will instead return a 404 JSON response just as NPM does when a package isn't found.

Cheers!
:cake:
