### PR TITLE
Fix underlying file access error for 404s when in offline mode

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,8 +44,8 @@ app.get( '/:package', function( req, res, next ){
         return fetchAndCacheMetadata( packageName, cacheFile );
       }
     })
-    .then( function( isExists ){
-      if ( !isExists ) {
+    .then( function( cacheState ){
+      if ( !cacheState ) {
         return false;
       }
       res._log.cacheFile = cacheFile;
@@ -79,9 +79,9 @@ app.get( '/:package/-/:tarball', function( req, res, next ){
         return fetchAndCacheTarball( packageName, version, packagePath );
       }
     })
-    .then( function( isExists ){
+    .then( function( cacheState ){
       res._log.cacheFile = packagePath;
-      if ( isExists ) {
+      if ( cacheState ) {
         return res.sendFile( packagePath );
       } else {
         res.status( 404 );


### PR DESCRIPTION
This fixes a problem that was masked by my having logging accidentally eaten while testing, unknown files while in offline mode would return the expect 404 and a blank json object, but internally an exception was bubbling up the stack due to trying to later send another response:

```
Error: Can't set headers after they are sent.
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:335:11)
    at ServerResponse.header (/home/ubuntu/npm-offline-registry/node_modules/express/lib/response.js:718:10)
    at ServerResponse.send (/home/ubuntu/npm-offline-registry/node_modules/express/lib/response.js:163:12)
    at ServerResponse.json (/home/ubuntu/npm-offline-registry/node_modules/express/lib/response.js:249:15)
    at ServerResponse.send (/home/ubuntu/npm-offline-registry/node_modules/express/lib/response.js:151:21)
    at /home/ubuntu/npm-offline-registry/app.js:96:7
    at Layer.handle_error (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/layer.js:71:5)
    at trim_prefix (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:310:13)
    at /home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:330:12)
    at next (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:271:10)
    at Layer.handle_error (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/layer.js:67:12)
    at trim_prefix (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:310:13)
    at /home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:280:7
    at Function.process_params (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:330:12)
    at next (/home/ubuntu/npm-offline-registry/node_modules/express/lib/router/index.js:271:10)
```

To fix this I've changed the initial `.tap()` in the file exists promise chain to be a `.then()` resolution so when can pass the file state to the next callback and use it with the `ENABLE_NPM_FAILOVER` flag, so that in cases were we have a legitimate file not found we can return the response without attempting to use the response any further.

Cheers!
:cake:
