### PR TITLE
Allow LOCAL_REGISTRY to be set from env

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -82,5 +82,5 @@ function onError(error) {
  */
 
 function onListening() {
-  console.log('Listening on http://' + config.LOCAL_REGISTRY );
+  console.log('Listening on http://0.0.0.0:' + port );
 }

--- a/config.js
+++ b/config.js
@@ -13,7 +13,10 @@ Object.keys( defaultConfig ).forEach( function(v){
 });
 
 
-config.LOCAL_REGISTRY = 'localhost:' + config.PORT;
+if( !config.LOCAL_REGISTRY ){
+  config.LOCAL_REGISTRY = 'localhost:' + config.PORT;
+}
+
 if( config.ENABLE_NPM_FAILOVER == 'false' ){
   config.ENABLE_NPM_FAILOVER = false;
 }

--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ Object.keys( defaultConfig ).forEach( function(v){
 
 
 if( !config.LOCAL_REGISTRY ){
-  config.LOCAL_REGISTRY = 'localhost:' + config.PORT;
+  config.LOCAL_REGISTRY = 'http://localhost:' + config.PORT;
 }
 
 if( config.ENABLE_NPM_FAILOVER == 'false' ){

--- a/utils.js
+++ b/utils.js
@@ -29,7 +29,11 @@ exports.readFile = readFile;
 exports.patchData = function ( data ){
   Object.keys(data.versions).forEach( function( v ){
     var val = data.versions[v];
-    val.dist.tarball = val.dist.tarball.replace( REGISTRY_NAME, LOCAL_REGISTRY );
+    var protocal = 'http://';
+    if( val.dist.tarball.indexOf( 'https:' ) !== false ){
+      protocal = 'https://';
+    }
+    val.dist.tarball = val.dist.tarball.replace( protocal + REGISTRY_NAME, LOCAL_REGISTRY );
   });
 };
 


### PR DESCRIPTION
This change just ensures `LOCAL_REGISTRY` is only set if not already set from process.env, which is handy in the case of deploying an alternative isolation registry with `ENABLE_NPM_FAILOVER` set to `false` and you want to serve a public URL (perhaps another frontend server or reverse proxy for example).

Cheers!
:cake:
