### PR TITLE
Return blank JSON objects for 404s, to match registry.npmjs.org

### DIFF
--- a/app.js
+++ b/app.js
@@ -94,7 +94,12 @@ app.use(function(req, res, next) {
 app.use(function(err, req, res, next) {
   err.stack && console.log( err.stack );
   res.status(err.status || 500);
-  res.send( err.message || err );
+  var message = err.message || err;
+  // NPM registry returns empty objects for unknown packages
+  if( err.status == 404 ){
+    message = {};
+  }
+  res.send( message );
   if( next ) { next(); }
 });
 


### PR DESCRIPTION
I've added a special case for 404s to return a blank JSON object (`{}`), which is what NPM returns, as some tools expect to be able to `JSON.parse()` responses even if the status is !={2,3}xx
