### PR TITLE
hello harish - this fixes the issue with scoped packages

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -39,7 +39,7 @@ exports.patchData = function ( data ){
 
 var fetchAndCacheMetadataCmd =[
   'mkdir -p $packageCacheDir',
-  'wget -nv "http://$REGISTRY_NAME/$packageName" -O $cacheFile || { wgetExitStatus=$? && rm $cacheFile; exit $wgetExitStatus ; }'
+  'wget -nv "http://$REGISTRY_NAME/$packageNameEncoded" -O $cacheFile || { wgetExitStatus=$? && rm $cacheFile; exit $wgetExitStatus ; }'
 ].join( ';' );
 
 var  fetchAndCacheTarballCmd = [
@@ -50,17 +50,20 @@ var  fetchAndCacheTarballCmd = [
 
 exports.fetchAndCacheMetadata = function ( packageName, cacheFile ){
   var packageCacheDir = path.dirname( cacheFile );
+  var packageNameEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
 
   return exec( fetchAndCacheMetadataCmd, {
     packageCacheDir: packageCacheDir,
     REGISTRY_NAME: REGISTRY_NAME,
-    packageName: packageName,
+    packageNameEncoded: packageNameEncoded,
     cacheFile: cacheFile,
   });
 };
 
 exports.fetchAndCacheTarball = function ( packageName, version, tarballPath ){
-  var tarballUrl = 'http://' + REGISTRY_NAME + '/' + packageName + '/-/' + packageName + '-' + version + '.tgz';
+  var packageNameEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
+  
+  var tarballUrl = 'http://' + REGISTRY_NAME + '/' + packageNameEncoded + '/-/' + packageNameEncoded + '-' + version + '.tgz';
   var packageTarballDir = path.dirname( tarballPath );
 
   return exec( fetchAndCacheTarballCmd, {

--- a/utils.js
+++ b/utils.js
@@ -63,7 +63,7 @@ exports.fetchAndCacheMetadata = function ( packageName, cacheFile ){
 
 exports.fetchAndCacheTarball = function ( packageName, version, tarballPath ){
   //handle slash in scoped package name but do not convert @
-  packageNapackageNamemeEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
+  packageName = encodeURIComponent(packageName).replace(/^%40/, '@');
   
   var tarballUrl = 'http://' + REGISTRY_NAME + '/' + packageName + '/-/' + packageName + '-' + version + '.tgz';
   var packageTarballDir = path.dirname( tarballPath );

--- a/utils.js
+++ b/utils.js
@@ -39,7 +39,7 @@ exports.patchData = function ( data ){
 
 var fetchAndCacheMetadataCmd =[
   'mkdir -p $packageCacheDir',
-  'wget -nv "http://$REGISTRY_NAME/$packageNameEncoded" -O $cacheFile || { wgetExitStatus=$? && rm $cacheFile; exit $wgetExitStatus ; }'
+  'wget -nv "http://$REGISTRY_NAME/$packageName" -O $cacheFile || { wgetExitStatus=$? && rm $cacheFile; exit $wgetExitStatus ; }'
 ].join( ';' );
 
 var  fetchAndCacheTarballCmd = [
@@ -51,21 +51,21 @@ var  fetchAndCacheTarballCmd = [
 exports.fetchAndCacheMetadata = function ( packageName, cacheFile ){
   var packageCacheDir = path.dirname( cacheFile );
   //handle slash in scoped package name but do not convert @
-  var packageNameEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
+  packageName = encodeURIComponent(packageName).replace(/^%40/, '@');
 
   return exec( fetchAndCacheMetadataCmd, {
     packageCacheDir: packageCacheDir,
     REGISTRY_NAME: REGISTRY_NAME,
-    packageNameEncoded: packageNameEncoded,
+    packageName: packageName,
     cacheFile: cacheFile,
   });
 };
 
 exports.fetchAndCacheTarball = function ( packageName, version, tarballPath ){
   //handle slash in scoped package name but do not convert @
-  var packageNameEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
+  packageNapackageNamemeEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
   
-  var tarballUrl = 'http://' + REGISTRY_NAME + '/' + packageNameEncoded + '/-/' + packageNameEncoded + '-' + version + '.tgz';
+  var tarballUrl = 'http://' + REGISTRY_NAME + '/' + packageName + '/-/' + packageName + '-' + version + '.tgz';
   var packageTarballDir = path.dirname( tarballPath );
 
   return exec( fetchAndCacheTarballCmd, {

--- a/utils.js
+++ b/utils.js
@@ -50,6 +50,7 @@ var  fetchAndCacheTarballCmd = [
 
 exports.fetchAndCacheMetadata = function ( packageName, cacheFile ){
   var packageCacheDir = path.dirname( cacheFile );
+  //handle slash in scoped package name but do not convert @
   var packageNameEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
 
   return exec( fetchAndCacheMetadataCmd, {
@@ -61,6 +62,7 @@ exports.fetchAndCacheMetadata = function ( packageName, cacheFile ){
 };
 
 exports.fetchAndCacheTarball = function ( packageName, version, tarballPath ){
+  //handle slash in scoped package name but do not convert @
   var packageNameEncoded = encodeURIComponent(packageName).replace(/^%40/, '@');
   
   var tarballUrl = 'http://' + REGISTRY_NAME + '/' + packageNameEncoded + '/-/' + packageNameEncoded + '-' + version + '.tgz';


### PR DESCRIPTION
scoped package names can add a slash into package names which is not getting encoded.

this fixes that and prevents @ from being encoded.

I don't know your code, so there might be a neater place for this, and I haven't changed you tests to test a scoped package name.

great package by the way, I think this is an enormously useful.
